### PR TITLE
Refocus webhook flow on Restream payloads

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,7 +9,9 @@ class Settings(BaseSettings):
     debug: bool = True
 
     # Webhook
-    restream_webhook_secret: str | None = Field(default=None, description="Optional webhook signing secret")
+    restream_webhook_secret: str | None = Field(
+        default=None, description="Optional webhook signing secret"
+    )
 
     # Groq Whisper
     groq_api_key: str | None = None
@@ -33,4 +35,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,22 +1,75 @@
 from datetime import datetime
-from pydantic import BaseModel, Field
 from typing import Optional
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class RestreamWebhook(BaseModel):
-    # Flexible fields to map common Restream-like payloads
+    # Flexible fields to map Restream-like payloads
     event: Optional[str] = None
-    stream_id: Optional[str] = Field(default=None, description="External stream/session id")
+    stream_id: Optional[str] = Field(
+        default=None, alias="streamId", description="External stream/session id"
+    )
     title: Optional[str] = None
-    media_url: Optional[str] = Field(default=None, description="Direct downloadable audio/video URL")
-    recording_url: Optional[str] = None
-    started_at: Optional[datetime] = None
-    ended_at: Optional[datetime] = None
-    # Raw passthrough
+    media_url: Optional[str] = Field(default=None, alias="mediaUrl")
+    recording_url: Optional[str] = Field(default=None, alias="recordingUrl")
+    started_at: Optional[datetime] = Field(default=None, alias="startedAt")
+    ended_at: Optional[datetime] = Field(default=None, alias="endedAt")
     data: Optional[dict] = None
 
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
     def effective_media_url(self) -> Optional[str]:
-        return self.media_url or self.recording_url or (self.data or {}).get("media_url") or (self.data or {}).get("recording_url")
+        if self.media_url:
+            return self.media_url
+        if self.recording_url:
+            return self.recording_url
+        if self.data and isinstance(self.data, dict):
+            for key in (
+                "recordingUrl",
+                "recording_url",
+                "mediaUrl",
+                "media_url",
+            ):
+                value = self.data.get(key)
+                if value:
+                    return value
+        return None
+
+    def resolved_stream_id(self) -> Optional[str]:
+        if self.stream_id:
+            return self.stream_id
+        if self.data and isinstance(self.data, dict):
+            candidate = self.data.get("streamId") or self.data.get("stream_id")
+            if candidate:
+                return candidate
+        return None
+
+    def resolved_title(self) -> Optional[str]:
+        if self.title:
+            return self.title
+        if self.data and isinstance(self.data, dict):
+            title = self.data.get("title")
+            if title:
+                return title
+        return None
+
+    def is_recording_ready_event(self) -> bool:
+        event_name = (self.event or "").lower()
+        if event_name in {
+            "recording.ready",
+            "recording_ready",
+            "stream.recording.ready",
+        }:
+            return True
+        if self.data and isinstance(self.data, dict):
+            nested_event = str(self.data.get("event") or "").lower()
+            return nested_event in {
+                "recording.ready",
+                "recording_ready",
+                "stream.recording.ready",
+            }
+        return False
 
 
 class StreamOut(BaseModel):
@@ -38,4 +91,3 @@ class StreamOut(BaseModel):
 class StreamDetail(StreamOut):
     transcript_text: Optional[str] = None
     summary_text: Optional[str] = None
-


### PR DESCRIPTION
## Summary
- remove the api.video service integration and related configuration knobs
- restore a Restream-oriented webhook schema with helpers for stream identifiers, media URLs, and event filtering
- update the webhook handler to validate signatures, skip non-recording events, upsert streams, and kick off processing using the provided recording URL

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68d53ba998f4832d97e5f6c340bb43ae